### PR TITLE
Updated method names in README to match code

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ You can then set parameters for both directly on the `Breadcrumb` object, for in
     
         $this->get('thormeier_breadcrumb.breadcrumb_provider')
             ->getBreadcrumbByRoute('acme_demo_product_detail')
-            ->setRouteParams(array(
+            ->setRouteParameters(array(
                 'id' => $product->getId(),
             ))
-            ->setLabelParams(array(
+            ->setLabelParameters(array(
                 'name' => $product->getName(),
             ));
             


### PR DESCRIPTION
The method names don't match what's actually in the code.